### PR TITLE
Add 'The Pragmatic Programmer in the Age of AI' (draft)

### DIFF
--- a/content/blog/the-pragmatic-programmer-in-the-age-of-ai.mdx
+++ b/content/blog/the-pragmatic-programmer-in-the-age-of-ai.mdx
@@ -1,0 +1,50 @@
+---
+title: "The Pragmatic Programmer in the Age of AI"
+date: "2026-06-11"
+excerpt: "You'd expect a book from before Git to feel dated next to AI agents. It doesn't. Five patterns from The Pragmatic Programmer that AI makes more obvious, not less."
+readTime: "3 min read"
+tags: ["Process", "Building", "Reflection"]
+draft: true
+---
+
+The Pragmatic Programmer came out in 1999. You'd expect a book from before Git existed to feel dated next to AI agents. It doesn't. The parts that hold up best are the ones AI makes more obvious, not less.
+
+I read it after I'd already built most of what's in it. Solo-founder work with Claude Code had me building skills, hooks, and audit procedures. The book gave them names and surfaced the gaps. Here are the five that mattered most.
+
+## orthogonality is a coupling problem you can measure
+
+The book's chapter on orthogonality is basically shoot-yourself-in-the-foot prevention. I learned it by hitting it. Every time I touched the work page in this portfolio, something elsewhere broke. The file was 1,192 lines, a god-component where every variation ended up. I refactored it last week, cut about a quarter off the line count, and made the rest safer to change.
+
+Here's what nobody mentions. Most coupling debt is invisible to lint and visible to git. If two files always change together, they're coupled, even if the import graph says otherwise. I built `/coupling` after noticing the pattern. Cycles and cross-layer imports are the easy half. Git co-change is where the actual rot lives.
+
+## DRY is the wrong word
+
+DRY gets read as 'don't repeat code,' which is the smallest version of it. The bigger version: every fact about the system lives in exactly one place. Astro dates, model IDs, brand colors, prices, URLs. When the same fact lives in three files, you don't have a copy-paste problem. You have a decision drift problem.
+
+Synestrology started with hand-typed astro data, and station dates were wrong in places. The code was DRY. The data wasn't. I built two things in response: a hook that catches hardcoded astro values at keystroke time, and a skill that sweeps for the judgment calls the hook can't pattern-match. One catches at keystroke, the other catches on demand. The book calls this 'automation.' In practice it's the only thing that holds.
+
+## tracer bullets vs prototypes
+
+The book is direct. Tracer bullets are end-to-end skeletons that ship and get fleshed out. Prototypes answer one question and get thrown away. Different tools, different mindsets.
+
+The honest pattern in industry is neither. It's 'prototype turned into production.' You write something to answer a question, it works well enough, you build the next thing on top of it. Six months later, the foundation of your product is code that was never meant to be a foundation. I've done this. Everyone I've shipped with has done it.
+
+Naming the call up front is most of the value. I built `/kickoff` to force a ten-minute conversation before non-trivial work starts: is this a tracer or a prototype, and if it's a prototype, what's the throw-away criterion. The skill doesn't fix the failure mode. The conversation does. The skill just makes the conversation cheap enough to actually have.
+
+## broken windows is a scheduling problem
+
+The book treats 'don't live with broken windows' as character. The version that actually works is putting the sweep on a calendar. Sentry won't interrupt you with rot at the right cadence. Stale draft posts won't either. Eight Dependabot PRs won't, until they're sixteen.
+
+What I learned solo: discipline at the right interval beats constant vigilance. Weekly Sentry digest reviewed against the accepted-risk doc. Monthly dependency batch. Quarterly stale draft cull. The book says don't let broken windows accumulate. The practical translation is: build the meeting with yourself, because nobody else is going to call it.
+
+## the spicy one: audits hallucinate at scale
+
+The book predates AI agents but still has the rule for using them: 'don't assume it, prove it.'
+
+Multi-agent audit tools, mine included, hallucinate findings at scale. The first time I ran a full audit sweep on this portfolio, the verification gate dropped 38% of findings as false positives. A flagged 'dead dependency' was actually loaded as a Tailwind plugin. Eighteen 'orphan images' were referenced dynamically. Three 'twin components' were distinct schema.org types.
+
+The verification step matters more than the audit. If you're using agents to check anything, code, content, or infra, the question isn't whether the agent found something. It's whether the finding survives a mechanical recheck. Treat agent output as a hypothesis, not a result. The book had this rule before AI existed. Different problem, same answer.
+
+---
+
+The book holds up because it isn't really about programming. It's about noticing small repetitions before they add up to chaos. Most of what I do as a solo founder is that work.

--- a/docs/sessions/2026-06-12-pragprog-blog-draft.md
+++ b/docs/sessions/2026-06-12-pragprog-blog-draft.md
@@ -1,0 +1,66 @@
+# Session: 2026-06-12 -- Draft "The Pragmatic Programmer in the Age of AI"
+
+## What happened
+
+- Drafted a new blog post `content/blog/the-pragmatic-programmer-in-the-age-of-ai.mdx`
+  as a sequel to `the-skill-layer` (2026-04-09). Frames five PragProg
+  principles (orthogonality, DRY, tracer bullets vs prototypes, broken
+  windows, audits hallucinate at scale) as patterns intuited via solo
+  founder reps, with `/coupling`, `/kickoff`, `/drift`, `/sentry-digest`
+  surfaced as offhand evidence rather than inventory.
+- Title arrived at after iteration: started as "I read The Pragmatic
+  Programmer last," changed to "The Pragmatic Programmer in the Age of AI"
+  to better match where the post lands. Opening tightened accordingly to
+  drop the meta inversion and lead with the AI-era angle.
+- Verification pass tightened multiple soft claims: dropped "two years
+  with Claude Code" (CC hasn't existed two years); 27% line reduction
+  softened to "about a quarter" (audit doc rounded; actual math is 26.4%);
+  "three components broke" generalized to "something elsewhere broke";
+  unverified 90% co-change threshold dropped to "always change together";
+  Synestrology wrong-date claim moved from "shipped a post with the wrong
+  station date" to "started with hand-typed astro data, station dates were
+  wrong in places" (matches what memory actually says); "twenty years ago"
+  corrected to "before AI existed" (book is 27); "every assumption gets
+  checked" replaced with the verbatim Tip 36 wording, "don't assume it,
+  prove it."
+- AI-speak stripped per voice ask: "encoded the same patterns" → "building
+  skills, hooks, and audit procedures. The book gave them names";
+  "absorbed every variation" → "where every variation ended up";
+  "mechanical enforcement plus on-demand audit" → "one catches at
+  keystroke, the other catches on demand"; "two different artifacts" →
+  "different tools"; "the principle still holds" → "different problem,
+  same answer"; "thoughtful person notices" → "noticing"; "AI tooling" →
+  "AI" in most places.
+- Final state: ~770 words, 3 min read, `draft: true`, single quotes
+  throughout, no em dashes, lowercase creative section headers consistent
+  with the rest of the blog.
+
+## Decisions made
+
+- Kept it principle-forward, with skills as evidence rather than the
+  subject. Didn't enumerate the skill count or use inventory tables; that
+  move would have read as obsessive after The Skill Layer already did the
+  table-and-count pass.
+- Left two soft spots for review rather than guessing: (1) the Synestrology
+  phrasing is the verifiable version, but the punchier "I shipped a post
+  with the wrong station date" is available if that incident actually
+  shipped; (2) the "ten-minute conversation" line on `/kickoff` is
+  illustrative; can drop the number if it reads as too specific.
+- Shipped as `draft: true`. Post is visible in dev, hidden in production.
+  Vercel auto-deploy is safe; the post will not appear on the live
+  listing until `draft` flips.
+
+## Known issues
+
+- None introduced by this session.
+- Carried forward from 2026-06-09: hero-banner.gif 36MB uncompressed,
+  8 open Dependabot PRs, 7 blog drafts outstanding (now 8 with this one),
+  `StructuredData.tsx` `dateModified` hand-typed literal.
+
+## Next session
+
+- Review pass on the draft. Decide on the two soft spots flagged above.
+- Flip `draft: false` when ready to publish; add a custom OG image if
+  desired (current fallback is `/og-image.png`).
+- Stale draft cull is overdue per the broken-windows section of this very
+  post; eight outstanding drafts is the threshold worth acting on.


### PR DESCRIPTION
## Summary

- Sequel to `the-skill-layer` (2026-04-09). Five PragProg principles framed as patterns intuited via solo founder work: orthogonality, DRY, tracer bullets vs prototypes, broken windows, audits hallucinate at scale.
- Skills (`/coupling`, `/kickoff`, `/drift`, `/sentry-digest`) appear as offhand evidence rather than inventory tables, by deliberate contrast with The Skill Layer's structure.
- Voice and verification pass complete: dropped unverifiable timing claims, corrected line-reduction math (about a quarter), replaced "every assumption gets checked" with the verbatim Tip 36 ("don't assume it, prove it"), stripped AI-speak throughout.

## Test plan

- [ ] Preview at `localhost:3000/writing/the-pragmatic-programmer-in-the-age-of-ai` and confirm it renders cleanly with the rest of the writing list
- [ ] Confirm it does NOT appear at `/writing` in production (it shouldn't — `draft: true`)
- [ ] Review the two soft spots flagged in `docs/sessions/2026-06-12-pragprog-blog-draft.md`
- [ ] Flip `draft: false` when ready to publish (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)