### PR TITLE
Replace mailto contact form with Calendly popup + email fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,12 @@ Defined in `tailwind.config.ts` and `src/app/globals.css`:
 |-------|---------------|-----|
 | Background | `bg-bg-base` | `#0B0C0E` |
 | Surface | `bg-surface` | `#14161A` |
-| Accent Teal | `text-accent-teal` | `#2BD4CF` |
+| Accent (electric fuchsia) | `text-accent-teal` | `#E930A8` |
+
+Note: the Tailwind token is still named `accent-teal` for historical reasons
+but the value was changed to electric fuchsia in commit `f6f609a` (2026-04-03).
+Renaming the token to `accent-fuchsia` is tracked drift; do not assume the
+literal hex is teal.
 
 ## Typography
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,189 +3,180 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
+import Script from 'next/script'
 import Sidebar from '@/components/Sidebar'
 import PageHero from '@/components/PageHero'
 import { useLenis } from '@/hooks/useLenis'
 
-const CONTACT_EMAIL = 'shaina@slabcheck.app'
+const CONTACT_EMAIL = 'me@shainapauley.com'
+const CALENDLY_URL =
+  'https://calendly.com/shainaep/30min?background_color=0B0C0E&text_color=ffffff&primary_color=E930A8&hide_landing_page_details=1&hide_gdpr_banner=1'
+
+declare global {
+  interface Window {
+    Calendly?: {
+      initPopupWidget: (options: { url: string }) => void
+    }
+  }
+}
 
 export default function Contact() {
   useLenis()
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    message: ''
-  })
+  const [copied, setCopied] = useState(false)
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }))
+  const openCalendly = () => {
+    if (window.Calendly) {
+      window.Calendly.initPopupWidget({ url: CALENDLY_URL })
+    } else {
+      window.open(CALENDLY_URL, '_blank', 'noopener,noreferrer')
+    }
   }
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    const subject = `New message from ${formData.name}`
-    const body = `${formData.message}\n\n---\nReply to: ${formData.email}`
-    const mailtoUrl = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
-
-    const a = document.createElement('a')
-    a.href = mailtoUrl
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
+  const copyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText(CONTACT_EMAIL)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      window.location.href = `mailto:${CONTACT_EMAIL}`
+    }
   }
 
   return (
-    <div className="min-h-screen grid lg:grid-cols-[340px_1fr]">
-      <Sidebar />
-      
-      <main id="main-content" className="px-4 lg:px-12 py-8 lg:py-12">
-        <div className="max-w-6xl mx-auto">
-          <PageHero
-            title="let's connect"
-            subtitle="Got something you're building and need help with? Tell me about it below and I'll send you a link to book a free 30-minute call."
-          />
+    <>
+      <link
+        rel="stylesheet"
+        href="https://assets.calendly.com/assets/external/widget.css"
+      />
+      <Script
+        src="https://assets.calendly.com/assets/external/widget.js"
+        strategy="lazyOnload"
+      />
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+      <div className="min-h-screen grid lg:grid-cols-[340px_1fr]">
+        <Sidebar />
+
+        <main id="main-content" className="px-4 lg:px-12 py-8 lg:py-12">
+          <div className="max-w-6xl mx-auto">
+            <PageHero
+              title="let's connect"
+              subtitle="Pick a time that works, or drop me a line:-)"
+            />
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+              <motion.div
+                className="space-y-8"
+                initial={{ opacity: 0, x: -50 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.8, delay: 0.5 }}
+              >
+                <div>
+                  <h2 className="text-accent-teal text-lg font-semibold mb-4">What I Do</h2>
+                  <ul className="space-y-2 text-gray-300">
+                    <li>• AI product architecture and agentic systems design</li>
+                    <li>• Specification design, evaluation systems, and context architecture</li>
+                    <li>• Production software built and maintained with AI-native workflows</li>
+                    <li>• Leading product when teams need direction</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h2 className="text-accent-teal text-lg font-semibold mb-4">Industries</h2>
+                  <ul className="space-y-2 text-gray-300">
+                    <li>• AI and machine learning systems</li>
+                    <li>• SaaS and enterprise software</li>
+                    <li>• Privacy-first consumer tools</li>
+                    <li>• Media, journalism, and information design</li>
+                  </ul>
+                </div>
+              </motion.div>
+
+              <motion.div
+                initial={{ opacity: 0, x: 50 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.8, delay: 0.7 }}
+              >
+                <div className="bg-surface border border-white/10 rounded-2xl p-8 space-y-6">
+                  <div>
+                    <h2 className="text-white text-2xl font-semibold mb-2">
+                      Book a 30-minute call
+                    </h2>
+                    <p className="text-gray-400 text-sm">
+                      Free intro call. We talk through what you're building, what you need, and whether we're a fit.
+                    </p>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={openCalendly}
+                    className="w-full bg-accent-teal hover:opacity-90 text-bg-base font-semibold py-3 px-6 rounded-lg transition-opacity"
+                  >
+                    Pick a time
+                  </button>
+
+                  <div className="pt-4 border-t border-white/10 space-y-3">
+                    <p className="text-gray-400 text-sm">What happens next:</p>
+                    <ol className="space-y-2 text-gray-300 text-sm">
+                      <li>1. You pick a slot that works for you.</li>
+                      <li>2. We talk through what you're building.</li>
+                      <li>3. We see if there's a fit.</li>
+                    </ol>
+                  </div>
+
+                  <div className="pt-4 border-t border-white/10">
+                    <p className="text-gray-400 text-sm mb-3">Prefer email?</p>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <a
+                        href={`mailto:${CONTACT_EMAIL}`}
+                        className="text-accent-teal hover:underline font-mono text-sm"
+                      >
+                        {CONTACT_EMAIL}
+                      </a>
+                      <button
+                        type="button"
+                        onClick={copyEmail}
+                        aria-label="Copy email address to clipboard"
+                        className="text-xs text-gray-300 hover:text-accent-teal px-3 py-1 border border-white/20 hover:border-accent-teal rounded transition-colors"
+                      >
+                        {copied ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+            </div>
+
             <motion.div
-              className="space-y-8"
-              initial={{ opacity: 0, x: -50 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.8, delay: 0.5 }}
+              className="mt-20 pt-16 border-t border-white/10"
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 0.9 }}
             >
-              <div>
-                <h2 className="text-accent-teal text-lg font-semibold mb-4">What I Do</h2>
-                <ul className="space-y-2 text-gray-300">
-                  <li>• AI product architecture and agentic systems design</li>
-                  <li>• Specification design, evaluation systems, and context architecture</li>
-                  <li>• Production software built and maintained with AI-native workflows</li>
-                  <li>• Leading product when teams need direction</li>
-                </ul>
-              </div>
+              <div className="flex flex-wrap justify-center items-center gap-6 md:gap-8">
+                <h2 className="text-white text-2xl md:text-3xl font-light tracking-wide">
+                  Find me on
+                </h2>
 
-              <div>
-                <h2 className="text-accent-teal text-lg font-semibold mb-4">Industries</h2>
-                <ul className="space-y-2 text-gray-300">
-                  <li>• AI and machine learning systems</li>
-                  <li>• SaaS and enterprise software</li>
-                  <li>• Privacy-first consumer tools</li>
-                  <li>• Media, journalism, and information design</li>
-                </ul>
-              </div>
-
-              <div>
-                <h2 className="text-accent-teal text-lg font-semibold mb-4">Response Time</h2>
-                <p className="text-gray-300">
-                  I typically respond within 24 hours.
-                </p>
-              </div>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, x: 50 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.8, delay: 0.7 }}
-            >
-              <form onSubmit={handleSubmit} className="space-y-6">
-                <div>
-                  <label htmlFor="name" className="block text-white font-semibold mb-2">
-                    Name *
-                  </label>
-                  <input
-                    type="text"
-                    id="name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleInputChange}
-                    required
-                    className="w-full px-4 py-3 bg-slate-800/50 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-accent-teal transition-colors"
-                    placeholder="Your full name"
-                  />
-                </div>
-
-                <div>
-                  <label htmlFor="email" className="block text-white font-semibold mb-2">
-                    Email *
-                  </label>
-                  <input
-                    type="email"
-                    id="email"
-                    name="email"
-                    value={formData.email}
-                    onChange={handleInputChange}
-                    required
-                    className="w-full px-4 py-3 bg-slate-800/50 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-accent-teal transition-colors"
-                    placeholder="your.email@example.com"
-                  />
-                </div>
-
-                <div>
-                  <label htmlFor="message" className="block text-white font-semibold mb-2">
-                    Message *
-                  </label>
-                  <textarea
-                    id="message"
-                    name="message"
-                    value={formData.message}
-                    onChange={handleInputChange}
-                    required
-                    rows={5}
-                    className="w-full px-4 py-3 bg-slate-800/50 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-accent-teal transition-colors resize-none"
-                    placeholder="Give me the quick version: what are you building and what do you need help with?"
-                  />
-                </div>
-
-                <button
-                  type="submit"
-                  className="w-full bg-teal-500 hover:bg-teal-600 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+                <a
+                  href="https://www.upwork.com/freelancers/~01678c95a70afbd270?mp_source=share"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group relative overflow-hidden rounded-2xl border-2 border-white/20 hover:border-accent-teal transition-all duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-teal-500/20 w-64 h-28 flex items-center justify-center"
                 >
-                  Send Message
-                </button>
-
-                <p className="text-sm text-gray-400 text-center">
-                  This opens your mail client. Prefer direct?{' '}
-                  <a href={`mailto:${CONTACT_EMAIL}`} className="text-accent-teal hover:underline">
-                    {CONTACT_EMAIL}
-                  </a>
-                </p>
-              </form>
+                  <Image
+                    src="/images/upwork-logo.png"
+                    alt="Upwork"
+                    width={220}
+                    height={70}
+                    className="object-contain transition-all duration-500 translate-y-3"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-r from-teal-500/0 via-teal-500/10 to-teal-500/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+                </a>
+              </div>
             </motion.div>
           </div>
-
-          <motion.div
-            className="mt-20 pt-16 border-t border-white/10"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.9 }}
-          >
-            <div className="flex flex-wrap justify-center items-center gap-6 md:gap-8">
-              <h2 className="text-white text-2xl md:text-3xl font-light tracking-wide">
-                Find me on
-              </h2>
-
-              <a
-                href="https://www.upwork.com/freelancers/~01678c95a70afbd270?mp_source=share"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group relative overflow-hidden rounded-2xl border-2 border-white/20 hover:border-accent-teal transition-all duration-500 hover:scale-105 hover:shadow-2xl hover:shadow-teal-500/20 w-64 h-28 flex items-center justify-center"
-              >
-                <Image
-                  src="/images/upwork-logo.png"
-                  alt="Upwork"
-                  width={220}
-                  height={70}
-                  className="object-contain transition-all duration-500 translate-y-3"
-                />
-                <div className="absolute inset-0 bg-gradient-to-r from-teal-500/0 via-teal-500/10 to-teal-500/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-              </a>
-
-            </div>
-          </motion.div>
-        </div>
-      </main>
-    </div>
+        </main>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- The old contact form built a `mailto:` URL via a fake `<a>` click. It silently failed for any visitor without a registered system mail handler (Chrome + Gmail-web users with no Apple Mail or Outlook configured). The button literally did nothing — confirmed by site owner.
- Replaced with a Calendly popup widget (primary CTA) + visible email address with click-to-copy button (secondary). Dual-CTA respects mixed-intent traffic: serious prospects book directly, casual askers email without committing to a slot.
- Calendly widget uses the vanilla embed script lazy-loaded via Next.js `<Script>`; no `react-calendly` npm dep, no peer-dep risk on React 19.
- Theme params on the Calendly URL match brand background + fuchsia accent: `background_color=0B0C0E&text_color=ffffff&primary_color=E930A8&hide_landing_page_details=1&hide_gdpr_banner=1`.
- Caught drift along the way: CLAUDE.md's design-tokens table listed `accent-teal` as `#2BD4CF`, but the value was changed to electric fuchsia `#E930A8` in commit f6f609a (2026-04-03). Fixed the hex in this PR; flagged the token *rename* (`accent-teal` → `accent-fuchsia`) as separate wide-blast work.

## What changed in the page

- Subtitle rewritten to drop the broken "I'll send you a link" promise
- Right column: form replaced with CTA card (title, description, "Pick a time" button, "What happens next" 3-step list, email + copy button)
- Removed "Response Time" block — the calendar is the response time
- Left column (What I Do / Industries) and "Find me on Upwork" section untouched
- Contact email constant updated `shaina@slabcheck.app` → `me@shainapauley.com`

## Test plan

- [ ] `/contact` loads with new CTA card visible
- [ ] "Pick a time" opens Calendly popup themed in fuchsia/dark to match the site
- [ ] "Copy" button copies `me@shainapauley.com` and shows "Copied" for 2s
- [ ] Email link opens default mail handler (for visitors who have one)
- [ ] Fallback: if Calendly script hasn't loaded yet, button opens Calendly in a new tab (never silent failure)
- [ ] Page renders correctly on mobile (single-column stack)
- [ ] Lighthouse/perf: Calendly script only loads on /contact, not site-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)