### PR TITLE
Add /skills page: free toolkit of Claude Code slash commands

### DIFF
--- a/content/blog/the-skill-layer.mdx
+++ b/content/blog/the-skill-layer.mdx
@@ -78,3 +78,7 @@ Pick the thing you explain to Claude most often. The workflow you repeat, the co
 From there, build the two that changed everything for me: `/onboard` (so Claude knows what it's working on) and `/session` (so the next conversation knows what happened in this one). Those two alone solve the biggest problem with AI-assisted development, which is context loss between sessions.
 
 The tool is capable enough. The bottleneck is how much of your operational knowledge lives in your head versus in a format Claude can execute.
+
+---
+
+Mine are free to install at [/skills](/skills).

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -81,6 +81,11 @@ export default function AboutPage() {
                 <span><strong>Results Over Activity</strong> ● Orthogonality, drift detection, dead-code sweeps, security review: my own toolkit for finding what's weak in your AI-built system.</span>
               </li>
             </ul>
+            <p className="text-zinc-500 text-sm mt-6">
+              <a href="/skills" className="hover:text-accent-teal transition-colors">
+                browse my skills →
+              </a>
+            </p>
           </div>
 
           <div className="mt-24 lg:mt-32">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -32,7 +32,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
-      url: `${SITE_URL}/method`,
+      url: `${SITE_URL}/skills`,
       lastModified: currentDate,
       changeFrequency: 'monthly',
       priority: 0.8,

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -8,7 +8,7 @@ export const metadata = buildRouteMetadata({
   title: 'Skills',
   slug: '/skills',
   description:
-    'A free audit toolkit for Claude Code. The slash commands I run on my own work, calibrated for my workflow.',
+    'A free audit toolkit for Claude Code. Fourteen slash commands for accessibility, performance, SEO, privacy, design, deploy safety, and codebase audits.',
 })
 
 export default function SkillsPage() {

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,0 +1,57 @@
+import Sidebar from '@/components/Sidebar'
+import PageHero from '@/components/PageHero'
+import { SkillCard } from '@/components/SkillCard'
+import { SKILLS, SKILLS_REPO, TIER_LABELS, TIERS } from '@/lib/skills'
+import { buildRouteMetadata } from '@/lib/metadata'
+
+export const metadata = buildRouteMetadata({
+  title: 'Skills',
+  slug: '/skills',
+  description:
+    'A free audit toolkit for Claude Code. The slash commands I run on my own work, calibrated for my workflow.',
+})
+
+export default function SkillsPage() {
+  return (
+    <div className="min-h-screen grid lg:grid-cols-[340px_1fr]">
+      <Sidebar />
+      <main id="main-content" className="px-4 lg:px-12 py-12 lg:py-20">
+        <div className="max-w-4xl mx-auto">
+          <PageHero
+            title="skills"
+            subtitle="The slash commands I run on my own work. Free to install, free to share, take what helps."
+          />
+
+          <p className="text-zinc-500 text-sm mb-16 max-w-2xl">
+            Each install command creates <code className="font-mono text-zinc-400">~/.claude/skills/&lt;name&gt;/</code> and downloads <code className="font-mono text-zinc-400">SKILL.md</code>. The{' '}
+            <a
+              href={SKILLS_REPO}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-400 hover:text-accent-teal transition-colors underline underline-offset-2"
+            >
+              full source
+            </a>{' '}
+            is on GitHub if you want to read before installing.
+          </p>
+
+          {TIERS.map((tier) => {
+            const tierSkills = SKILLS.filter((s) => s.tier === tier)
+            return (
+              <section key={tier} className="mb-16">
+                <h2 className="text-2xl lg:text-3xl font-bold text-white mb-6 lowercase">
+                  {TIER_LABELS[tier]}
+                </h2>
+                <div className="space-y-4">
+                  {tierSkills.map((skill) => (
+                    <SkillCard key={skill.slug} skill={skill} />
+                  ))}
+                </div>
+              </section>
+            )
+          })}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+import { buildInstallCommand, SKILLS_REPO, type Skill } from '@/lib/skills'
+
+function ClipboardIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  )
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  )
+}
+
+export function SkillCard({ skill }: { skill: Skill }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(buildInstallCommand(skill.slug))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <article className="bg-white/[0.03] backdrop-blur-sm rounded-2xl p-6 lg:p-8 border border-white/10 hover:border-accent-teal/50 transition-all duration-300">
+      <h3 className="text-xl lg:text-2xl font-bold text-accent-teal font-mono mb-3">
+        /{skill.slug}
+      </h3>
+      <p className="text-zinc-300 leading-relaxed mb-5">
+        {skill.description}
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-sm rounded-lg transition-colors"
+          aria-label={`Copy install command for /${skill.slug}`}
+        >
+          {copied ? <CheckIcon /> : <ClipboardIcon />}
+          <span>{copied ? 'copied' : 'install'}</span>
+        </button>
+        <a
+          href={`${SKILLS_REPO}/blob/main/${skill.slug}/SKILL.md`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 text-zinc-400 hover:text-accent-teal text-sm rounded-lg transition-colors"
+        >
+          <ExternalLinkIcon />
+          <span>view source</span>
+        </a>
+      </div>
+    </article>
+  )
+}

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,0 +1,109 @@
+export type Tier = 'toolkit' | 'foundations' | 'workflow'
+
+export type Skill = {
+  slug: string
+  description: string
+  tier: Tier
+}
+
+export const SKILLS_REPO = 'https://github.com/Surfrrosa/claude-skills'
+export const SKILLS_RAW = 'https://raw.githubusercontent.com/Surfrrosa/claude-skills/main'
+
+export function buildInstallCommand(slug: string): string {
+  return `mkdir -p ~/.claude/skills/${slug} && curl -L ${SKILLS_RAW}/${slug}/SKILL.md -o ~/.claude/skills/${slug}/SKILL.md`
+}
+
+export const TIER_LABELS: Record<Tier, string> = {
+  toolkit: 'the toolkit',
+  foundations: 'foundations',
+  workflow: 'workflow',
+}
+
+export const TIERS: Tier[] = ['toolkit', 'foundations', 'workflow']
+
+export const SKILLS: Skill[] = [
+  {
+    slug: 'full-sweep',
+    tier: 'toolkit',
+    description:
+      'Orchestrates the audit-class skills in a single Plan Mode run. Auto-commits the mechanical wins, files the rest. Use before launch or monthly.',
+  },
+  {
+    slug: 'drift',
+    tier: 'toolkit',
+    description:
+      'Finds every place code drifts from a canonical source of truth. Hand-typed data, magic numbers, copy that fell out of sync with brand docs.',
+  },
+  {
+    slug: 'cohesion',
+    tier: 'toolkit',
+    description:
+      "Finds every place a page drifts from the project's design system. Different button styles, hard-coded colors that should be tokens, parallel classes recreating canonical components.",
+  },
+  {
+    slug: 'coupling',
+    tier: 'toolkit',
+    description:
+      'Orthogonality audit. Asks the Pragmatic Programmer\'s question, "if I change feature X, how many modules light up?" with mechanical evidence.',
+  },
+  {
+    slug: 'walkthrough',
+    tier: 'toolkit',
+    description:
+      'UX coverage audit. State-machine gaps, missing features (no logout, no password reset), entry-state combinations nobody walked through.',
+  },
+  {
+    slug: 'thatsweird',
+    tier: 'toolkit',
+    description:
+      'Browser and OS edge-case sweep. Chrome auto-dark inversion on dark sites, iOS rubber-band flash, iOS input zoom, prefers-reduced-motion violations.',
+  },
+  {
+    slug: 'design',
+    tier: 'toolkit',
+    description:
+      'Design psychology audit. Asks "does the system serve the user?" not "does the page match the system?" Evaluates typography, color register, brand-voice match.',
+  },
+  {
+    slug: 'a11y',
+    tier: 'foundations',
+    description:
+      'Accessibility (WCAG) audit on source code and optionally live URLs. Can auto-fix safe categories.',
+  },
+  {
+    slug: 'perf',
+    tier: 'foundations',
+    description:
+      'Performance audit. Bundle size, image weight, render-blocking resources, and Core Web Vitals via PageSpeed.',
+  },
+  {
+    slug: 'seo',
+    tier: 'foundations',
+    description:
+      'SEO health audit across projects. Score them, identify gaps, optionally fix.',
+  },
+  {
+    slug: 'privacy',
+    tier: 'foundations',
+    description:
+      'Audit data collection, consent flows, exposed secrets, and privacy policy accuracy.',
+  },
+  {
+    slug: 'onboard',
+    tier: 'workflow',
+    description:
+      "Digest a repository's architecture, docs, conventions, and current state before starting work.",
+  },
+  {
+    slug: 'ship',
+    tier: 'workflow',
+    description:
+      'Pre-deploy safety checklist. Catches build failures, leaked secrets, debug artifacts, missing env vars.',
+  },
+  {
+    slug: 'session',
+    tier: 'workflow',
+    description:
+      'End-of-session log generator. What changed, decisions made, next steps.',
+  },
+]

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,4 +1,4 @@
-export type Tier = 'foundations' | 'design' | 'workflow'
+export type Tier = 'toolkit' | 'foundations' | 'workflow'
 
 export type Skill = {
   slug: string
@@ -14,14 +14,56 @@ export function buildInstallCommand(slug: string): string {
 }
 
 export const TIER_LABELS: Record<Tier, string> = {
+  toolkit: 'the toolkit',
   foundations: 'foundations',
-  design: 'design',
   workflow: 'workflow',
 }
 
-export const TIERS: Tier[] = ['foundations', 'design', 'workflow']
+export const TIERS: Tier[] = ['toolkit', 'foundations', 'workflow']
 
 export const SKILLS: Skill[] = [
+  {
+    slug: 'full-sweep',
+    tier: 'toolkit',
+    description:
+      'Orchestrates the audit-class skills in a single Plan Mode run. Auto-commits the mechanical wins, files the rest as issues. Use before launch or monthly.',
+  },
+  {
+    slug: 'drift',
+    tier: 'toolkit',
+    description:
+      'Finds every place code drifts from a canonical source of truth. Hand-typed reference data, magic numbers, copy that fell out of sync with brand docs.',
+  },
+  {
+    slug: 'cohesion',
+    tier: 'toolkit',
+    description:
+      "Finds every place a page drifts from the project's design system. Different button styles, hard-coded colors that should be tokens, parallel classes recreating canonical components.",
+  },
+  {
+    slug: 'coupling',
+    tier: 'toolkit',
+    description:
+      'Orthogonality audit. Asks the Pragmatic Programmer\'s question, "if I change feature X, how many modules light up?" with mechanical evidence.',
+  },
+  {
+    slug: 'walkthrough',
+    tier: 'toolkit',
+    description:
+      'UX coverage audit. State-machine gaps, missing features (no logout, no password reset), entry-state combinations nobody walked through.',
+  },
+  {
+    slug: 'thatsweird',
+    tier: 'toolkit',
+    description:
+      'Browser and OS edge-case sweep. Chrome auto-dark inversion on dark sites, iOS rubber-band flash, iOS input zoom, prefers-reduced-motion violations.',
+  },
+  {
+    slug: 'design',
+    tier: 'toolkit',
+    description:
+      'Design psychology audit. Asks "does the system serve the user?" not "does the page match the system?" Evaluates typography, color register, brand-voice match.',
+  },
   {
     slug: 'a11y',
     tier: 'foundations',
@@ -45,18 +87,6 @@ export const SKILLS: Skill[] = [
     tier: 'foundations',
     description:
       'Audit data collection, consent flows, exposed secrets, and privacy policy accuracy.',
-  },
-  {
-    slug: 'design',
-    tier: 'design',
-    description:
-      'Design psychology audit. Asks "does the system serve the user?" not "does the page match the system?" Evaluates typography, color register, brand-voice match.',
-  },
-  {
-    slug: 'thatsweird',
-    tier: 'design',
-    description:
-      'Browser and OS edge-case sweep. Chrome auto-dark inversion on dark sites, iOS rubber-band flash, iOS input zoom, prefers-reduced-motion violations.',
   },
   {
     slug: 'onboard',

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,4 +1,4 @@
-export type Tier = 'toolkit' | 'foundations' | 'workflow'
+export type Tier = 'foundations' | 'design' | 'workflow'
 
 export type Skill = {
   slug: string
@@ -14,56 +14,14 @@ export function buildInstallCommand(slug: string): string {
 }
 
 export const TIER_LABELS: Record<Tier, string> = {
-  toolkit: 'the toolkit',
   foundations: 'foundations',
+  design: 'design',
   workflow: 'workflow',
 }
 
-export const TIERS: Tier[] = ['toolkit', 'foundations', 'workflow']
+export const TIERS: Tier[] = ['foundations', 'design', 'workflow']
 
 export const SKILLS: Skill[] = [
-  {
-    slug: 'full-sweep',
-    tier: 'toolkit',
-    description:
-      'Orchestrates the audit-class skills in a single Plan Mode run. Auto-commits the mechanical wins, files the rest. Use before launch or monthly.',
-  },
-  {
-    slug: 'drift',
-    tier: 'toolkit',
-    description:
-      'Finds every place code drifts from a canonical source of truth. Hand-typed data, magic numbers, copy that fell out of sync with brand docs.',
-  },
-  {
-    slug: 'cohesion',
-    tier: 'toolkit',
-    description:
-      "Finds every place a page drifts from the project's design system. Different button styles, hard-coded colors that should be tokens, parallel classes recreating canonical components.",
-  },
-  {
-    slug: 'coupling',
-    tier: 'toolkit',
-    description:
-      'Orthogonality audit. Asks the Pragmatic Programmer\'s question, "if I change feature X, how many modules light up?" with mechanical evidence.',
-  },
-  {
-    slug: 'walkthrough',
-    tier: 'toolkit',
-    description:
-      'UX coverage audit. State-machine gaps, missing features (no logout, no password reset), entry-state combinations nobody walked through.',
-  },
-  {
-    slug: 'thatsweird',
-    tier: 'toolkit',
-    description:
-      'Browser and OS edge-case sweep. Chrome auto-dark inversion on dark sites, iOS rubber-band flash, iOS input zoom, prefers-reduced-motion violations.',
-  },
-  {
-    slug: 'design',
-    tier: 'toolkit',
-    description:
-      'Design psychology audit. Asks "does the system serve the user?" not "does the page match the system?" Evaluates typography, color register, brand-voice match.',
-  },
   {
     slug: 'a11y',
     tier: 'foundations',
@@ -87,6 +45,18 @@ export const SKILLS: Skill[] = [
     tier: 'foundations',
     description:
       'Audit data collection, consent flows, exposed secrets, and privacy policy accuracy.',
+  },
+  {
+    slug: 'design',
+    tier: 'design',
+    description:
+      'Design psychology audit. Asks "does the system serve the user?" not "does the page match the system?" Evaluates typography, color register, brand-voice match.',
+  },
+  {
+    slug: 'thatsweird',
+    tier: 'design',
+    description:
+      'Browser and OS edge-case sweep. Chrome auto-dark inversion on dark sites, iOS rubber-band flash, iOS input zoom, prefers-reduced-motion violations.',
   },
   {
     slug: 'onboard',


### PR DESCRIPTION
## Summary

Publishes 14 of my Claude Code slash commands as a free, MIT-licensed audit toolkit. Each skill is mirrored at [Surfrrosa/claude-skills](https://github.com/Surfrrosa/claude-skills); this PR adds the discoverable landing page on the portfolio.

The register is intentionally a gift: no sales CTAs, no "book a call" funnel at the bottom of the page, no promotion beyond the two link surfaces called out below.

## What's in it

**New `/skills` page** with three sections:

- **the toolkit** — the differentiated audit-class skills: `/full-sweep`, `/drift`, `/cohesion`, `/coupling`, `/walkthrough`, `/thatsweird`, `/design`
- **foundations** — `/a11y`, `/perf`, `/seo`, `/privacy`
- **workflow** — `/onboard`, `/ship`, `/session`

Each skill card has:
- Skill name in mono/accent
- One-line description
- `[install]` button — copies a one-liner that creates `~/.claude/skills/<name>/` and downloads the SKILL.md
- `[view source]` link to the canonical file on GitHub

**Two subtle link surfaces:**
- `/about` — small "browse my skills →" under the "What I Bring" bullets
- `/writing/the-skill-layer` — closing line: "Mine are free to install at /skills."

**No other promo.** No sidebar link, no /work card, no contact CTA on the page itself.

## Files

| File | Purpose |
|------|---------|
| `src/lib/skills.ts` | Skill data + install command builder + tier ordering |
| `src/components/SkillCard.tsx` | Card with clipboard copy + GitHub link, inline feather SVGs |
| `src/app/skills/page.tsx` | Server component, exports metadata, renders Sidebar + PageHero + 3 tier sections |
| `src/app/about/page.tsx` | Added subtle link below bullets |
| `content/blog/the-skill-layer.mdx` | Added closing line linking to /skills |

## Design coherence

- Card style mirrors `/writing` exactly: `bg-white/[0.03] backdrop-blur-sm rounded-2xl border border-white/10 hover:border-accent-teal/50`
- Uses existing `PageHero` component for hero
- Lowercase title voice matches "stuff i've been working on" / "navigating mind, machine, & modern unease"
- No new tokens, no new fonts, no new dependencies
- Inline feather SVGs (clipboard, check, external-link), matches the existing icon pattern in `Sidebar.tsx`
- No em dashes, no emojis

## Test plan

- [ ] Page loads at `/skills`
- [ ] All three tiers render with cards
- [ ] `[install]` button copies the correct one-liner to clipboard
- [ ] `[install]` button text changes to "copied" briefly after click
- [ ] `[view source]` opens the right GitHub URL
- [ ] /about page shows "browse my skills →" link below bullets
- [ ] /writing/the-skill-layer renders the closing line and link
- [ ] Mobile layout works (sidebar collapses, cards stack)
- [ ] No build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)