### PR TITLE
Remove skills link from /about

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -81,11 +81,6 @@ export default function AboutPage() {
                 <span><strong>Results Over Activity</strong> ● Orthogonality, drift detection, dead-code sweeps, security review: my own toolkit for finding what's weak in your AI-built system.</span>
               </li>
             </ul>
-            <p className="text-zinc-500 text-sm mt-6">
-              <a href="/skills" className="hover:text-accent-teal transition-colors">
-                browse my skills →
-              </a>
-            </p>
           </div>
 
           <div className="mt-24 lg:mt-32">


### PR DESCRIPTION
Removes the 'browse my skills →' link from the about page. Skills page stays discoverable via the-skill-layer blog post.