### PR TITLE
Migrate personal-context memory into per-repo CLAUDE shelves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Personal/local Claude context (see CLAUDE.md for committed shared rules)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,27 @@ draft: false
 
 Posts with `draft: true` are hidden in production but visible in dev.
 
+### Voice
+
+Understated and efficient, not self-congratulatory:
+
+- **Minimize first person.** Use 'we' instead of 'I' when describing build work (the partner is Claude Code, so 'we' is accurate). Prefer passive/impersonal construction when possible: "this is what was done" over "I did this."
+- **No redundancy.** Never restate the same idea twice. Not trying to hit a word count.
+- **No gloating.** State what was built, not how impressive it is.
+- **Be honest about timelines.** Things described as taking "weeks" often took days or hours. Don't inflate effort.
+- **Earn every sentence.** Elegant and efficient. Never use "vibes and shipping" or similar try-hard casual phrasing.
+- **Never frame testing/process as an afterthought.** Builds happen with tests and process from the start — baked in, not bolted on after things break.
+
+### Single quotes for prose
+
+Use single quotes for all quoted phrases, dialog, and referenced terms in blog post bodies. Use double quotes only for nested quotes or cases where single quotes would collide with apostrophes in a way that hurts readability. (Also memorialized in `.claude/commands/blog.md` Hard Rules.)
+
+### Substack-suffix posts (3 posts) — leave the suffix
+
+Three posts carry "(Substack)" in their title — `synthetic-intimacy.mdx`, `the-shadow-economy-of-silence.mdx`, `you-are-the-marketplace.mdx`. The suffix is **deliberate**: it signals to readers that these were written in a different style and perspective than the current portfolio voice, and warns of the tonal mismatch.
+
+Don't strip the "(Substack)" suffix even though the Substack itself no longer exists. The original commit message ("Tag Substack-origin posts with '(Substack)' suffix") makes it sound like origin-tracking and tempts removal — it isn't. Leave it alone.
+
 ## Branching
 
 - `main` -- production, auto-deploys to Vercel


### PR DESCRIPTION
## Summary

Migrates 5 portfolio-related memory files out of the always-loaded auto-memory layer into this repo's two CLAUDE files using the Anthropic-recommended three-shelf pattern:

- **`CLAUDE.md` (committed)** — extends the existing Blog Posts section with three additions useful to any future editor: voice rules (no gloating, no redundancy, honest timelines, minimize first person), single-quote convention for prose, and the "(Substack)" suffix preserve rule for three legacy posts.
- **`CLAUDE.local.md` (gitignored, new)** — personal positioning history (2026-03-28 AI Product Architect repositioning) + 1:1-only service definition (what to sell + what NOT to propose as portfolio changes).

## Files

| File | Change |
|------|--------|
| `.gitignore` | +1 entry for `CLAUDE.local.md` |
| `CLAUDE.md` | +24 lines extending the Blog Posts section |
| `CLAUDE.local.md` | New file, gitignored, ~60 lines (not in this PR — exists only on Shaina's local disk) |

## Test plan

- [x] `git check-ignore CLAUDE.local.md` returns the gitignore entry (confirmed locally)
- [x] `CLAUDE.local.md` does NOT appear in `git status` after creation (confirmed locally)
- [ ] After merge, future Claude sessions in this repo load all three shelves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)