### PR TITLE
Dedupe package.json, restore React 19.2.8 runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "gray-matter": "4.0.3",
         "lenis": "1.3.23",
         "next": "16.2.12",
-        "react": "19.2.5",
-        "react-dom": "19.2.5",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "react-markdown": "10.1.0",
         "remark-gfm": "4.0.1",
         "swiper": "12.1.4"
@@ -7144,9 +7144,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7154,16 +7154,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,9 @@
     "framer-motion": "12.38.0",
     "gray-matter": "4.0.3",
     "lenis": "1.3.23",
-    "next": "16.2.7",
+    "next": "16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "next": "16.2.12",
-    "react": "19.2.5",
-    "react-dom": "19.2.5",
     "react-markdown": "10.1.0",
     "remark-gfm": "4.0.1",
     "swiper": "12.1.4"


### PR DESCRIPTION
## Summary

- Removes duplicate `next` / `react` / `react-dom` keys in `package.json` from a bad Dependabot merge conflict resolution when PR #161 rebased over #159.
- Restores React runtime to `19.2.8` to match `@types/react` at `19.2.17`.

## Context

Under JS object-literal last-write-wins parsing, the second block of duplicate keys was silently overriding PR #159's React bump:

```
"next": "16.2.7",         // ← ignored
"react": "19.2.8",        // ← ignored (correct value, wrong position)
"react-dom": "19.2.8",    // ← ignored
"next": "16.2.12",        // ← effective (correct)
"react": "19.2.5",        // ← effective (WRONG — should be 19.2.8)
"react-dom": "19.2.5",    // ← effective (WRONG — should be 19.2.8)
```

Effective post-PR-#161 state was React runtime `19.2.5` + types `19.2.17`. Not a crash-class bug, but a real runtime/types drift that would eventually surface as a hard-to-explain TS error or subtle behavioral difference. Flagged in PR #164's body as a follow-up.

## Test plan

- [x] `npm install` clean (rebuilt lockfile, `react`/`react-dom` now resolve to `19.2.8`)
- [x] `npm run build` succeeds locally (32 pages, TS compile ~2s)
- [ ] Vercel preview deploy green
- [ ] Production deploy green post-merge