### PR TITLE
Add 'One Year in Linear > Eight Years in Jira' blog post

### DIFF
--- a/content/blog/one-year-in-linear.mdx
+++ b/content/blog/one-year-in-linear.mdx
@@ -1,0 +1,52 @@
+---
+title: "One Year in Linear > Eight Years in Jira"
+date: "2026-08-02"
+excerpt: "Eight years in Jira and Jira Align, one year in Linear running two apps. Here's what actually changed and where each tool still wins."
+readTime: "3 min read"
+tags: ["Product Management", "Process", "Reflection"]
+draft: false
+---
+
+I worked in Jira and Jira Align for a little over eight years. Running Scrum and Kanban with my own teams, planning across departments and executive layers, fulfilling company initiatives, setting up and configuring workflows from time to time.
+
+A year ago, I moved my own work to Linear. Two apps, Synestrology and SlabCheck, from the start. Technical work, feature planning, marketing, legal, admin, everything in the same tool.
+
+## what linear removes
+
+The pitch usually goes 'Linear is faster than Jira.' That's real, but the interesting part is that there are no workflow diagrams. No custom field schemas. No setup tables. Issue states are minimal. You don't design your process, you use theirs.
+
+For a solo builder or a small team, the time I used to spend keeping Jira useful is time I now spend shipping.
+
+## what actually works day to day
+
+Keyboard-first. Cmd+K opens a command palette that runs the whole app. Most things take no more than a couple of keystrokes.
+
+The GitHub integration is the one Linear nailed. Reference an issue in a PR title or commit message with 'Closes SYN-142' and the issue moves through states as the PR does, then closes on merge. No mental overhead to keep the tracker in sync with the code.
+
+The Vercel integration surfaces deploy previews directly on issues. One click from ticket to preview when you're iterating on a fix.
+
+The setup that most changes my day: Claude with the Linear MCP integration. Claude drafts issues, updates status, and pulls context directly from Linear. Sentry runs through the same layer. Instead of a native Sentry-to-Linear integration that would auto-file every event, Claude reads Sentry, triages, and only files what's worth filing.
+
+There's also the small stuff: saved filtered views per project, a triage inbox for incoming issues, an instant-feel UI (local-first architecture, no loading spinners) that most tools don't invest in.
+
+And it's fun. Reactions, GIFs, comment threads that feel like the tool was made by people who care about the craft. Not assembled by committee.
+
+## what jira still does better
+
+Jira Align propagates work across executive layers, connects portfolios to strategy, and gives leadership visibility across dozens of teams with different processes. Linear doesn't touch that.
+
+Permission schemes, audit trails, and formal change management workflows matter in regulated industries like finance, healthcare, and SOX-compliant environments. Jira handles them.
+
+Near-limitless customization is a real advantage when you need the tool to bend to a specific taxonomy or an unusual process. Jira bends further.
+
+The step down from all of that to Linear has been seamless and natural.
+
+## where linear starts to bite
+
+The free tier caps at 250 active issues per workspace. 'Active' is Linear's word for non-archived, so Done and Canceled count. I have two projects, and I'm now hitting the ceiling regularly on both. Manual archive doesn't exist at any tier (a product decision, not a paywall), so auto-archive is the only option. When you hit the cap, you're playing janitor rather than shipping.
+
+It's annoying, so an upgrade is on the table.
+
+## what's next
+
+Cycles, Linear's version of sprints, is a feature I haven't turned on. Solo and small-team work moves faster without them. Once SlabCheck goes to market and cadence matters more, that's where I might pick them up.


### PR DESCRIPTION
## Summary
- New blog post covering one year in Linear (Synestrology + SlabCheck) after eight years in Jira and Jira Align.
- Fact-checked against Linear and Atlassian docs; uses Linear's own 'active issues' terminology per their pricing page.
- No custom OG image; falls back to default og-image.png.

## Test plan
- [ ] Post renders at /writing/one-year-in-linear
- [ ] Frontmatter fields (title, date, tags, readTime, excerpt) render correctly
- [ ] OG metadata and Twitter card populate from frontmatter