### PR TITLE
Trim excerpt on 'One Year in Linear' post

### DIFF
--- a/content/blog/one-year-in-linear.mdx
+++ b/content/blog/one-year-in-linear.mdx
@@ -1,7 +1,7 @@
 ---
 title: "One Year in Linear > Eight Years in Jira"
 date: "2026-08-02"
-excerpt: "Eight years in Jira and Jira Align, one year in Linear running two apps. Here's what actually changed and where each tool still wins."
+excerpt: "Eight years in Jira and Jira Align, one year in Linear running two apps."
 readTime: "3 min read"
 tags: ["Product Management", "Process", "Reflection"]
 draft: false


### PR DESCRIPTION
## Summary
- Removes the trailing 'Here's what actually changed and where each tool still wins' from the excerpt.
- Applies to the /writing listing card and the OG / meta description.

## Test plan
- [ ] Excerpt on /writing card shows only the opening line
- [ ] OG / Twitter card meta description updates on next deploy