### PR TITLE
Change 'One Year in Linear' post title to remove greater-than comparison

### DIFF
--- a/content/blog/one-year-in-linear.mdx
+++ b/content/blog/one-year-in-linear.mdx
@@ -1,5 +1,5 @@
 ---
-title: "One Year in Linear > Eight Years in Jira"
+title: "One year in Linear, after eight years in Jira"
 date: "2026-08-02"
 excerpt: "Eight years in Jira and Jira Align, one year in Linear running two apps."
 readTime: "3 min read"


### PR DESCRIPTION
## Summary
- Retitles the post from 'One Year in Linear > Eight Years in Jira' to 'One year in Linear, after eight years in Jira'.
- The '>' framed the piece as an absolute value claim (Linear beats Jira) that the body doesn't actually make. New title reflects the actual thesis: transition + reflection.
- URL slug unchanged.

## Test plan
- [ ] Card on /writing shows new title
- [ ] Post page /writing/one-year-in-linear shows new title in h1 and browser tab
- [ ] OG / Twitter card meta title updates on next deploy