### PR TITLE
Add acceptance update to 'Applying to the Claude Partner Network' post

### DIFF
--- a/content/blog/applying-to-the-claude-partner-network.mdx
+++ b/content/blog/applying-to-the-claude-partner-network.mdx
@@ -7,6 +7,8 @@ tags: ["Claude Code", "Building", "AI Development"]
 draft: false
 ---
 
+> **Update:** I've been an official Claude partner since May 2026 and am currently working on the Claude Certified Architect Certification.
+
 ## why
 
 There are three reasons I wanted to do this.


### PR DESCRIPTION
## Summary
- Adds a top-of-post update noting Claude partner acceptance (May 2026) and ongoing Claude Certified Architect certification work.
- Closes the loop on the original post's 'I'll write more once I complete the entire process' commitment.

## Test plan
- [ ] Post at /writing/applying-to-the-claude-partner-network renders the update as a blockquote above the intro
- [ ] Rest of the post unchanged