### PR TITLE
Note Prompt2Story sunset on 'Hardest Thing I Shipped in 2025' post

### DIFF
--- a/content/blog/the-hardest-thing-i-shipped-2025.mdx
+++ b/content/blog/the-hardest-thing-i-shipped-2025.mdx
@@ -80,3 +80,5 @@ Prompt2Story currently does one thing: take messy input, generate structured out
 **Try it:** [prompt2story.com](https://www.prompt2story.com)
 
 *Over 1,000 stories generated for teams in 20+ countries.*
+
+*Prompt2Story was sunset in June 2026, one of several personal projects I've retired to focus my time on Synestrology and SlabCheck. The site is no longer live.*


### PR DESCRIPTION
## Summary
- Adds an italic sunset line under the closing stats on `the-hardest-thing-i-shipped-2025.mdx`, keeping the existing CTA and stats intact.
- Names the June 2026 sunset and the reason (consolidating on Synestrology and SlabCheck).
- Matches the sunset-line pattern used on the two Absurdity Index posts, with reason wording added because Prompt2Story had real users and warrants the context.

## Test plan
- [ ] `npm run build` passes on Vercel preview
- [ ] Post renders with the new italic line directly beneath the "Over 1,000 stories generated" line
- [ ] "Try it: prompt2story.com" CTA still present (per Shaina's explicit ask to keep it)