### PR TITLE
Reframe /about as one-line founder positioning

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,132 +1,44 @@
 'use client'
 
-import Image from 'next/image'
 import { motion } from 'framer-motion'
 import Sidebar from '@/components/Sidebar'
-import BottomCTAs from '@/components/BottomCTAs'
-import { useLenis } from '@/hooks/useLenis'
 
 export default function AboutPage() {
-  useLenis({ duration: 1.1, orientation: 'vertical', gestureOrientation: 'vertical', infinite: false })
-
   return (
     <div className="min-h-screen grid lg:grid-cols-[340px_1fr]">
       <Sidebar />
 
-      <main id="main-content" className="flex flex-col px-4 lg:px-12 py-12 lg:py-20">
+      <main
+        id="main-content"
+        className="flex items-center justify-center min-h-screen px-4 lg:px-12 py-12 lg:py-20"
+      >
         <h1 className="sr-only">About Shaina Pauley</h1>
-        <motion.div
-          className="text-center relative w-full max-w-4xl mx-auto"
-          initial={{ opacity: 0, y: 50 }}
+        <motion.p
+          className="text-white text-center leading-relaxed max-w-[70ch] mx-auto text-xl lg:text-[2rem]"
+          initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 1, delay: 0.3 }}
+          transition={{ duration: 0.8, delay: 0.4 }}
         >
-          <motion.p
-            className="text-white leading-relaxed max-w-[70ch] mx-auto text-zinc-200 text-xl lg:text-[2rem]"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.4 }}
+          founder @{' '}
+          <a
+            href="https://synestrology.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-teal hover:text-white transition-colors"
           >
-            <strong className="font-bold">AI Product Architect</strong> and <strong className="font-bold">builder</strong> who ships production software with AI in the terminal every day.
-          </motion.p>
-
-          <motion.div
-            className="flex items-center justify-center gap-4 mt-8"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.8, delay: 0.6 }}
+            Synestrology
+          </a>
+          , co-founder @{' '}
+          <a
+            href="https://slabcheck.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-teal hover:text-white transition-colors"
           >
-            <Image
-              src="/images/cspo-badge.png"
-              alt="CSPO Certified"
-              width={52}
-              height={52}
-              className="inline-block"
-            />
-            <span className="text-zinc-400 text-xs lg:text-base tracking-wide">
-              CSPO (Certified Scrum Product Owner)
-            </span>
-            <span className="text-zinc-500 text-lg">•</span>
-            <Image
-              src="/images/csm-badge.png"
-              alt="CSM Certified"
-              width={60}
-              height={60}
-              className="inline-block"
-            />
-            <span className="text-zinc-400 text-xs lg:text-base tracking-wide">
-              CSM (Certified ScrumMaster)
-            </span>
-          </motion.div>
-        </motion.div>
-
-        <section className="mt-16 lg:mt-24">
-          <div className="max-w-4xl mx-auto text-white">
-            <h2 className="text-3xl lg:text-4xl font-bold mb-6 lg:mb-8">What I Bring</h2>
-            <ul className="space-y-6 text-lg leading-relaxed">
-              <li className="flex items-start">
-                <span className="text-accent-teal mr-4 mt-1">•</span>
-                <span><strong>7+ Years in the Trenches</strong> ● secure authentication, REST APIs, CRM, migrations, dashboards.</span>
-              </li>
-              <li className="flex items-start">
-                <span className="text-accent-teal mr-4 mt-1">•</span>
-                <span><strong>AI Systems Architect</strong> ● specification design, evaluation systems, agentic workflows, production guardrails.</span>
-              </li>
-              <li className="flex items-start">
-                <span className="text-accent-teal mr-4 mt-1">•</span>
-                <span><strong>Speaks Both Languages</strong> ● I can talk to engineers about architecture and simplify it for non-technical teams and stakeholders so everyone's aligned.</span>
-              </li>
-              <li className="flex items-start">
-                <span className="text-accent-teal mr-4 mt-1">•</span>
-                <span><strong>Results Over Activity</strong> ● Orthogonality, drift detection, dead-code sweeps, security review: my own toolkit for finding what's weak in your AI-built system.</span>
-              </li>
-            </ul>
-          </div>
-
-          <div className="mt-24 lg:mt-32">
-            <BottomCTAs />
-          </div>
-
-          <div className="max-w-4xl mx-auto text-white mt-24 lg:mt-32">
-            <h2 className="text-3xl lg:text-4xl font-bold mb-8 lg:mb-12">Frequently Asked Questions</h2>
-            <div className="space-y-8">
-              <div>
-                <h3 className="text-xl lg:text-2xl font-semibold mb-3 text-accent-teal">What's an AI Product Architect?</h3>
-                <p className="text-gray-300 text-lg leading-relaxed">
-                  I sit between the technical and the strategic. I can read code, debug agent failures, and talk to stakeholders. I own the what and the why, then build the structure that makes complex systems reliable in production.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xl lg:text-2xl font-semibold mb-3 text-accent-teal">How do you use AI in product work?</h3>
-                <p className="text-gray-300 text-lg leading-relaxed">
-                  I architect the systems that AI works inside. That means writing the specifications agents follow, building evaluation pipelines that catch errors before they ship, and designing context architecture so every session picks up where the last one left off. I run multi-agent workflows for everything from astronomical verification to content generation, and I push back constantly on what the AI gives me.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xl lg:text-2xl font-semibold mb-3 text-accent-teal">What types of teams do you work with?</h3>
-                <p className="text-gray-300 text-lg leading-relaxed">
-                  Product-focused teams across industries: SaaS, enterprise tools, consumer apps. From 1:1 work with founders to early-stage and scale-up. Teams that value shipping over endless planning.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xl lg:text-2xl font-semibold mb-3 text-accent-teal">What's your typical engagement look like?</h3>
-                <p className="text-gray-300 text-lg leading-relaxed">
-                  Building things, designing how AI systems work, making sure what ships actually holds up, and leading product when teams need it. I work with people who need someone technical enough to get in the code and sharp enough to know what to prioritize. I also love helping teams work together better. Open communication, everyone feeling heard, and genuine alignment.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xl lg:text-2xl font-semibold mb-3 text-accent-teal">What's your availability?</h3>
-                <p className="text-gray-300 text-lg leading-relaxed">
-                  Currently taking on new clients who are interested in learning to build with AI. Drop me a note and tell me what you're building.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
+            SlabCheck
+          </a>
+          , &amp; current grad student
+        </motion.p>
       </main>
     </div>
   )

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -37,7 +37,7 @@ export default function AboutPage() {
           >
             SlabCheck
           </a>
-          , &amp; current grad student
+          , &amp; grad student
         </motion.p>
       </main>
     </div>


### PR DESCRIPTION
## Summary
Replaces the full AI-Product-Architect service-mode page with a single centered line:

> founder @ [Synestrology](https://synestrology.com), co-founder @ [SlabCheck](https://slabcheck.app), & current grad student

Product names link out to `synestrology.com` and `slabcheck.app`.

## Dropped
- Hero "AI Product Architect and builder" line + CSPO / CSM badges
- "What I Bring" section (4 bullets)
- Bottom View My Work / Get in Touch CTAs (sidebar already links both)
- All 5 consulting-framed FAQs (types of teams, engagement, taking on new clients, etc.)
- Unused imports and hooks that supported the dropped content

## Why
Positioning reflects full-time focus on Synestrology + SlabCheck plus a starting master's program. Contact page stays open for general inquiries; nothing on `/about` sells a service.

## Test plan
- [x] `npm run build` passes clean
- [ ] Vercel preview build passes
- [ ] CodeQL passes
- [ ] Preview renders: one line centered vertically, both product names as accent-color links opening in new tab