### PR TITLE
Rework /about corner tag + slide sidebar in on landing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -74,7 +74,7 @@ export default function AboutPage() {
           transition={{ duration: 0.6, delay: 1.2 }}
         >
           <p className="text-white/70 text-xs font-mono whitespace-nowrap overflow-hidden text-ellipsis">
-            now playing: let&apos;s all go to the lobby (1957) + a colour box (1935) · public domain
+            now playing: let&apos;s all go to the lobby (1957) + a colour box (1935)
           </p>
           <button
             type="button"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -68,34 +68,23 @@ export default function AboutPage() {
           <source src="/videos/about-hero.mp4" type="video/mp4" />
         </video>
         <motion.div
-          className="absolute bottom-8 left-1/2 -translate-x-1/2 px-6 py-3 rounded-2xl bg-black/40 backdrop-blur-md border border-white/10 max-w-[min(92vw,640px)]"
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 1.5 }}
+          className="absolute bottom-0 right-0 z-10 flex items-center gap-3 px-4 py-2 bg-black/40 backdrop-blur-md border-t border-l border-white/10 max-w-[92vw] overflow-hidden"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.6, delay: 1.2 }}
         >
-          <p className="text-white/60 text-xs font-mono text-center leading-relaxed">
+          <p className="text-white/70 text-xs font-mono whitespace-nowrap overflow-hidden text-ellipsis">
             now playing: let&apos;s all go to the lobby (1957) + a colour box (1935) · public domain
           </p>
-          <div className="flex items-center justify-center gap-4 mt-1">
-            <p className="text-white text-sm font-mono">
-              contact:{' '}
-              <a
-                href="mailto:me@shainapauley.com"
-                className="text-accent-teal hover:text-white transition-colors"
-              >
-                me@shainapauley.com
-              </a>
-            </p>
-            <button
-              type="button"
-              onClick={toggleMute}
-              className="text-white/70 hover:text-white transition-colors"
-              aria-label={isMuted ? 'Unmute video' : 'Mute video'}
-              title={isMuted ? 'Click to unmute' : 'Click to mute'}
-            >
-              {isMuted ? <MutedIcon /> : <UnmutedIcon />}
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={toggleMute}
+            className="shrink-0 text-white/70 hover:text-white transition-colors"
+            aria-label={isMuted ? 'Unmute video' : 'Mute video'}
+            title={isMuted ? 'Click to unmute' : 'Click to mute'}
+          >
+            {isMuted ? <MutedIcon /> : <UnmutedIcon />}
+          </button>
         </motion.div>
       </main>
     </>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -188,7 +188,12 @@ function DesktopSidebar() {
   const reducedMotion = useReducedMotion()
 
   useEffect(() => {
-    setIsExpanded(!isCollapsibleRoute)
+    if (isCollapsibleRoute) {
+      setIsExpanded(false)
+      const timer = setTimeout(() => setIsExpanded(true), 500)
+      return () => clearTimeout(timer)
+    }
+    setIsExpanded(true)
   }, [isCollapsibleRoute])
 
   const animDuration = reducedMotion ? 0 : 0.3


### PR DESCRIPTION
## Summary
Two tweaks based on feedback that the bottom-center pill detracts from the video's immersion.

## Changes

**1. Bottom-right rectangle tag** (replaces the centered pill)
- Sharp corners, subtle top + left borders (protrudes from the bottom-right edge of the viewport)
- Single line: `now playing: let's all go to the lobby (1957) + a colour box (1935) · public domain` + inline sound toggle
- Slides in from the right on load
- No contact info here (moving elsewhere on the site in a follow-up)

**2. Sidebar slides in on landing** (was: stayed collapsed until user clicked chevron)
- On any collapsible route, sidebar starts collapsed and slides in ~500ms after landing
- Landing on `/about` now: video appears first, then the sidebar slides in from the left as a small welcome flourish
- Chevron still toggles for anyone who wants full-immersion mode

## Test plan
- [x] `npm run build` passes clean
- [ ] Vercel preview builds
- [ ] `/about` preview: video autoplays, rectangle tag anchored bottom-right with credit + sound toggle on one line, sidebar slides in from left ~0.5s after landing
- [ ] Click chevron → sidebar collapses; click again → expands
- [ ] Other pages unchanged