### PR TITLE
Reverse /about sidebar entrance direction (visible → hides gracefully)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -202,15 +202,15 @@ function NavLinks({ className, onClick }: { className: string; onClick?: () => v
 function DesktopSidebar() {
   const pathname = usePathname()
   const isCollapsibleRoute = COLLAPSIBLE_ROUTES.includes(pathname as typeof COLLAPSIBLE_ROUTES[number])
-  const [isExpanded, setIsExpanded] = useState(!isCollapsibleRoute)
+  const [isExpanded, setIsExpanded] = useState(true)
   const [isEntering, setIsEntering] = useState(false)
   const reducedMotion = useReducedMotion()
 
   useEffect(() => {
     if (isCollapsibleRoute) {
-      setIsExpanded(false)
+      setIsExpanded(true)
       setIsEntering(true)
-      const timer = setTimeout(() => setIsExpanded(true), 500)
+      const timer = setTimeout(() => setIsExpanded(false), 300)
       return () => clearTimeout(timer)
     }
     setIsExpanded(true)
@@ -224,7 +224,7 @@ function DesktopSidebar() {
       : { type: 'tween' as const, duration: 0.3, ease: 'easeInOut' as const }
 
   const handleAnimationComplete = () => {
-    if (isEntering && isExpanded) setIsEntering(false)
+    if (isEntering && !isExpanded) setIsEntering(false)
   }
 
   return (


### PR DESCRIPTION
## Summary
Had the direction backwards. The intended UX was: sidebar visible on landing, then gracefully slides away into hiding (chevron pulls it back). What we shipped was the opposite: sidebar hidden on landing, pops in.

## Fix
- Initial `isExpanded` state now `true` (visible from first render on direct nav or refresh)
- On collapsible routes, `useEffect` triggers a slide-out after a short 300ms beat, running the 900ms ease-out transition
- `handleAnimationComplete` now flips `isEntering` off when the collapse animation finishes (was: when expand animation finished)

Chevron tab still toggles as before.

## Test plan
- [x] `npm run build` passes clean
- [ ] Vercel preview builds
- [ ] `/about` preview: sidebar visible on landing, gracefully slides away to the left after a brief beat, chevron remains
- [ ] Click chevron → snap-expands; click again → snap-collapses
- [ ] Other pages unchanged