### PR TITLE
Reframe metadata + Person schema around founder positioning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,11 +23,11 @@ export const viewport: Viewport = {
 
 export const metadata: Metadata = {
   title: {
-    default: 'Shaina Pauley | AI Product Architect',
+    default: 'it me | shaina pauley',
     template: '%s | Shaina Pauley'
   },
-  description: 'AI Product Architect. I design the systems AI works inside: specifications, evaluation pipelines, context that persists between sessions. 7+ years in product, now building with AI every day.',
-  keywords: ['AI Product Architect', 'Agentic Systems Design', 'AI Evaluation Harnesses', 'Multi-Agent Orchestration', 'Context Architecture', 'Claude Code', 'AI-Native Development', 'Product Architecture', 'Shaina Pauley'],
+  description: 'founder @ synestrology & co-founder @ SlabCheck · let\'s have a kiki',
+  keywords: ['Shaina Pauley', 'Synestrology', 'SlabCheck', 'Founder', 'Pokemon TCG', 'Astrology Software', 'Human Design'],
   authors: [{ name: 'Shaina Pauley', url: SITE_URL }],
   creator: 'Shaina Pauley',
   publisher: 'Shaina Pauley',
@@ -44,8 +44,8 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: 'Shaina Pauley | AI Product Architect',
-    description: 'I design the systems AI works inside. Specifications, evaluation pipelines, context that sticks between sessions. Building with AI every day.',
+    title: 'it me | shaina pauley',
+    description: 'founder @ synestrology & co-founder @ SlabCheck · let\'s have a kiki',
     url: SITE_URL,
     siteName: 'Shaina Pauley',
     type: 'website',
@@ -55,15 +55,15 @@ export const metadata: Metadata = {
         url: '/og-image.png',
         width: 1200,
         height: 630,
-        alt: 'Shaina Pauley - AI Product Architect',
+        alt: 'Shaina Pauley - founder of Synestrology and co-founder of SlabCheck',
         type: 'image/png',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Shaina Pauley | AI Product Architect',
-    description: 'I design the systems AI works inside. Specifications, evaluation pipelines, context that sticks between sessions. Building with AI every day.',
+    title: 'it me | shaina pauley',
+    description: 'founder @ synestrology & co-founder @ SlabCheck · let\'s have a kiki',
     images: ['/og-image.png'],
     creator: '@sha1napauley',
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
       <Sidebar />
 
       <main id="main-content" className="flex flex-col items-center px-4 lg:px-12 h-auto lg:min-h-screen pt-0 lg:justify-center relative overflow-visible">
-        <h1 className="sr-only">Shaina Pauley | AI Product Architect</h1>
+        <h1 className="sr-only">Shaina Pauley</h1>
         <motion.div
           className="text-center relative w-full"
           initial={{ opacity: 0, y: 50 }}

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -25,18 +25,18 @@ function buildPersonSchema() {
       "https://github.com/Surfrrosa",
       "https://x.com/sha1napauley"
     ],
-    "jobTitle": "AI Product Architect",
+    "jobTitle": "Founder",
     "knowsAbout": [
+      "Synestrology",
+      "SlabCheck",
+      "Astrology Software",
+      "Human Design",
+      "Pokemon TCG Grading",
       "AI Product Architecture",
       "Agentic Systems Design",
-      "Multi-Agent Orchestration",
-      "AI Evaluation Harnesses",
-      "Context Architecture",
-      "Claude Code",
-      "AI-Native Development",
-      "Product Strategy"
+      "Claude Code"
     ],
-    "description": "AI Product Architect. I design the systems AI works inside: specifications, evaluation pipelines, context that persists between sessions. 7+ years in product, now building with AI every day.",
+    "description": "Founder of Synestrology and co-founder of SlabCheck. Building both full-time while starting a master's in biomedical neuroscience at the University of Florida.",
     "hasCredential": [
       {
         "@type": "EducationalOccupationalCredential",
@@ -68,39 +68,12 @@ function buildWebPageSchema() {
     "@type": "WebPage",
     "@id": `${SITE_URL}/#webpage`,
     "url": SITE_URL,
-    "name": "Shaina Pauley | AI Product Architect",
+    "name": "it me | shaina pauley",
     "isPartOf": { "@id": `${SITE_URL}/#website` },
     "about": { "@id": `${SITE_URL}/#person` },
     "datePublished": "2025-01-01",
-    "dateModified": "2026-03-27",
-    "description": "AI Product Architect. I design the systems AI works inside: specifications, evaluation pipelines, context that persists between sessions."
-  }
-}
-
-function buildServiceOffer(name: string) {
-  return { "@type": "Offer", "itemOffered": { "@type": "Service", name } }
-}
-
-function buildServiceSchema() {
-  const services = [
-    "AI Product Architecture",
-    "Agentic Systems Design",
-    "Multi-Agent Orchestration",
-    "AI Evaluation and Quality Systems",
-    "Context Architecture and AI Workflow Design"
-  ]
-  return {
-    "@type": "ProfessionalService",
-    "@id": `${SITE_URL}/#service`,
-    "name": "Shaina Pauley - AI Product Architecture",
-    "provider": { "@id": `${SITE_URL}/#person` },
-    "serviceType": "AI Product Architecture and Agentic Systems Design",
-    "areaServed": "Worldwide",
-    "hasOfferCatalog": {
-      "@type": "OfferCatalog",
-      "name": "Services",
-      "itemListElement": services.map(buildServiceOffer)
-    }
+    "dateModified": "2026-08-16",
+    "description": "Founder of Synestrology and co-founder of SlabCheck."
   }
 }
 
@@ -111,7 +84,6 @@ export default function StructuredData() {
       buildPersonSchema(),
       buildWebSiteSchema(),
       buildWebPageSchema(),
-      buildServiceSchema(),
     ]
   }
 


### PR DESCRIPTION
## Summary
Google snippet, OG cards, Twitter cards, and Person entity data still declared "Shaina Pauley | AI Product Architect" and consultant service framing. Everything gets aligned with the founder positioning that `/about` now leads with.

## Changes

**`layout.tsx`:**
- Title (default + OG + Twitter): `it me | shaina pauley`
- Description (root + OG + Twitter): `founder @ synestrology & co-founder @ SlabCheck · let's have a kiki`
- Keywords: dropped consultant-shop terms (AI Product Architect, Agentic Systems, etc.); new set is name + product names + relevant domain terms
- OG image alt: reflects founder-of-Synestrology-and-SlabCheck

**`StructuredData.tsx`:**
- Person `jobTitle`: `AI Product Architect` → `Founder`
- Person `description`: founder framing including the master's context (informative for Google's Knowledge Panel)
- Person `knowsAbout`: reordered — product names first, then AI skills (still true, positive signal for AI-related searches)
- WebPage `name` + `description`: aligned with new title / positioning
- WebPage `dateModified` bumped to today
- **`ProfessionalService` schema deleted entirely** — it declared paid service offerings that are no longer accurate now that `/about` is a video and there's no service page

**Homepage sr-only h1:** `Shaina Pauley | AI Product Architect` → `Shaina Pauley` (clean, screen-reader friendly, no lingering consultant framing)

## Test plan
- [x] `npm run build` passes clean
- [ ] Vercel preview builds
- [ ] Preview → view page source → `<title>` reads `it me | shaina pauley`
- [ ] JSON-LD in the preview head shows Person.jobTitle = "Founder", no ProfessionalService schema present