### PR TITLE
Lowercase all route titles and refresh stale /about + /work descriptions

### DIFF
--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,11 +1,11 @@
 import { buildRouteMetadata } from '@/lib/metadata'
 
 export const metadata = buildRouteMetadata({
-  title: 'About',
+  title: 'about',
   slug: '/about',
-  description: 'AI Product Architect with 7+ years enterprise experience. Designs agentic systems, builds evaluation harnesses, and architects context for production AI workflows. CSPO and CSM certified.',
-  ogTitle: 'About Shaina Pauley',
-  ogDescription: 'AI Product Architect with 7+ years enterprise experience. Designs agentic systems, evaluation harnesses, and context architecture for production AI workflows.',
+  description: 'hi, it me. founder @ synestrology & co-founder @ SlabCheck.',
+  ogTitle: 'about shaina pauley',
+  ogDescription: 'hi, it me. founder @ synestrology & co-founder @ SlabCheck.',
 })
 
 export default function AboutLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   title: {
     default: 'it me | shaina pauley',
-    template: '%s | Shaina Pauley'
+    template: '%s | shaina pauley'
   },
   description: 'founder @ synestrology & co-founder @ SlabCheck · let\'s have a kiki',
   keywords: ['Shaina Pauley', 'Synestrology', 'SlabCheck', 'Founder', 'Pokemon TCG', 'Astrology Software', 'Human Design'],

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -5,7 +5,7 @@ import { SKILLS, SKILLS_REPO, TIER_LABELS, TIERS } from '@/lib/skills'
 import { buildRouteMetadata } from '@/lib/metadata'
 
 export const metadata = buildRouteMetadata({
-  title: 'Skills',
+  title: 'skills',
   slug: '/skills',
   description:
     'A free audit toolkit for Claude Code. Fourteen slash commands for accessibility, performance, SEO, privacy, design, deploy safety, and codebase audits.',

--- a/src/app/work/layout.tsx
+++ b/src/app/work/layout.tsx
@@ -1,11 +1,11 @@
 import { buildRouteMetadata } from '@/lib/metadata'
 
 export const metadata = buildRouteMetadata({
-  title: 'Work',
+  title: 'work',
   slug: '/work',
-  description: 'Portfolio of AI-native projects built with agentic workflows: Synestrology (multi-agent synthesis engine with astronomical verification), SlabCheck (Pokemon TCG grading decision tool), Maestro CLI, and enterprise product work.',
-  ogTitle: 'Work by Shaina Pauley',
-  ogDescription: 'AI-native projects built with agentic workflows: multi-agent systems, evaluation pipelines, CLI tools, data dashboards, and enterprise product architecture.',
+  description: 'founder work: synestrology, slabcheck, prism, and other builds.',
+  ogTitle: 'work by shaina pauley',
+  ogDescription: 'founder work: synestrology, slabcheck, prism, and other builds.',
 })
 
 export default function WorkLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -5,7 +5,7 @@ import WritingStructuredData from '@/components/WritingStructuredData'
 import { buildRouteMetadata } from '@/lib/metadata'
 
 export const metadata = buildRouteMetadata({
-  title: 'Navigating Mind, Machine, & Modern Unease',
+  title: 'navigating mind, machine, & modern unease',
   slug: '/writing',
   description: 'Essays on staying human.',
 })

--- a/src/components/ArticleStructuredData.tsx
+++ b/src/components/ArticleStructuredData.tsx
@@ -37,7 +37,7 @@ export default function ArticleStructuredData({
       '@id': `${SITE_URL}/#person`,
       name: 'Shaina Pauley',
       url: SITE_URL,
-      jobTitle: 'AI Product Architect',
+      jobTitle: 'Founder',
     },
     publisher: {
       '@type': 'Person',


### PR DESCRIPTION
## Summary

Google Search was still showing the retired **AI Product Architect / 7+ years enterprise experience** copy on `/about` (spotted in a live SERP screenshot). The root layout was updated in PR #190 but the per-route `layout.tsx` files were missed. Also caught two orthogonal drifts:

- Root title template was `%s | Shaina Pauley` in Title Case, so every per-route title (`About`, `Work`, `Skills`, writing landing) rendered against the current lowercase `it me | shaina pauley` register.
- `ArticleStructuredData.tsx` still carried `jobTitle: 'AI Product Architect'` for the blog-post author, conflicting with the sitewide Person schema (`jobTitle: 'Founder'`) sharing the same `@id`.

## Changes

- **Root template:** `%s | shaina pauley`
- **/about:** title `about`, description `hi, it me. founder @ synestrology & co-founder @ SlabCheck.`
- **/work:** title `work`, description `founder work: synestrology, slabcheck, prism, and other builds.`
- **/skills:** title `skills` (description was already fine)
- **/writing:** title `navigating mind, machine, & modern unease` (matches the H1)
- **ArticleStructuredData:** `jobTitle` `AI Product Architect` -> `Founder`

## Test plan

- [ ] Vercel preview build passes
- [ ] Preview: view-source on `/`, `/about`, `/work`, `/skills`, `/writing` and confirm `<title>` + `<meta name="description">` render lowercase and match the new copy
- [ ] Preview: view-source on a blog post and confirm the injected Article JSON-LD `author.jobTitle` is `Founder`
- [ ] After merge, request re-indexing in Google Search Console for `/about`, `/work`, `/`, and the writing landing so the SERP snippets refresh sooner than the natural 1-3 week cadence